### PR TITLE
Allows users to adjust Message bubble size

### DIFF
--- a/at_chat_flutter/lib/screens/chat_screen.dart
+++ b/at_chat_flutter/lib/screens/chat_screen.dart
@@ -19,8 +19,8 @@ class ChatScreen extends StatefulWidget {
   final Color receiverAvatarColor;
   final String title;
   final String? hintText;
-  final double bubble_height;
-  final double bubble_width;
+  final double bubbleHeightPadding;
+  final double bubbleWidthPadding;
 
   /// Widget to display chats as a screen or a bottom sheet.
   /// [height] specifies the height of bottom sheet/screen,
@@ -38,7 +38,9 @@ class ChatScreen extends StatefulWidget {
       this.senderAvatarColor = CustomColors.defaultColor,
       this.receiverAvatarColor = CustomColors.defaultColor,
       this.title = 'Messages',
-      this.hintText, this.bubble_height = 12.0, this.bubble_width = 12.0})
+      this.hintText, 
+      this.bubbleHeightPadding = 12.0, 
+      this.bubbleWidthPadding = 12.0})
       : super(key: key);
   @override
   _ChatScreenState createState() => _ChatScreenState();
@@ -145,8 +147,8 @@ class _ChatScreenState extends State<ChatScreen> {
                                       child: snapshot.data![index].type ==
                                               MessageType.INCOMING
                                           ? IncomingMessageBubble(
-                                              bubble_height: widget.bubble_height,
-                                              bubble_width: widget.bubble_width,
+                                              bubbleHeightPadding: widget.bubbleHeightPadding,
+                                              bubbleWidthPadding: widget.bubbleWidthPadding,
                                               message: snapshot.data![index],
                                               color:
                                                   widget.incomingMessageColor,
@@ -154,8 +156,8 @@ class _ChatScreenState extends State<ChatScreen> {
                                                   widget.senderAvatarColor,
                                             )
                                           : OutgoingMessageBubble(
-                                              bubble_height: widget.bubble_height,
-                                              bubble_width: widget.bubble_width,
+                                              bubbleHeightPadding: widget.bubbleHeightPadding,
+                                              bubbleWidthPadding: widget.bubbleWidthPadding,
                                               message: snapshot.data![index],
                                               color:
                                                   widget.outgoingMessageColor,

--- a/at_chat_flutter/lib/screens/chat_screen.dart
+++ b/at_chat_flutter/lib/screens/chat_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:at_chat_flutter/widgets/incoming_message_bubble.dart';
 import 'package:at_chat_flutter/widgets/outgoing_message_bubble.dart';
-// import 'package:at_chat_flutter/widgets/incoming_message_bubble.dart';
 
 import 'package:at_chat_flutter/widgets/send_message.dart';
 // ignore: import_of_legacy_library_into_null_safe

--- a/at_chat_flutter/lib/screens/chat_screen.dart
+++ b/at_chat_flutter/lib/screens/chat_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:at_chat_flutter/widgets/incoming_message_bubble.dart';
 import 'package:at_chat_flutter/widgets/outgoing_message_bubble.dart';
+// import 'package:at_chat_flutter/widgets/incoming_message_bubble.dart';
+
 import 'package:at_chat_flutter/widgets/send_message.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:at_common_flutter/services/size_config.dart';
@@ -18,6 +20,8 @@ class ChatScreen extends StatefulWidget {
   final Color receiverAvatarColor;
   final String title;
   final String? hintText;
+  final double bubble_height;
+  final double bubble_width;
 
   /// Widget to display chats as a screen or a bottom sheet.
   /// [height] specifies the height of bottom sheet/screen,
@@ -26,7 +30,6 @@ class ChatScreen extends StatefulWidget {
   /// [incomingMessageColor] defines the color of incoming message color.
   /// [title] specifies the title text to be displayed.
   /// [hintText] specifies the hint text to be displayed in the input box.
-
   const ChatScreen(
       {Key? key,
       this.height,
@@ -36,7 +39,7 @@ class ChatScreen extends StatefulWidget {
       this.senderAvatarColor = CustomColors.defaultColor,
       this.receiverAvatarColor = CustomColors.defaultColor,
       this.title = 'Messages',
-      this.hintText})
+      this.hintText, this.bubble_height = 12.0, this.bubble_width = 12.0})
       : super(key: key);
   @override
   _ChatScreenState createState() => _ChatScreenState();
@@ -76,7 +79,7 @@ class _ChatScreenState extends State<ChatScreen> {
             topRight: Radius.circular(10.toHeight),
           ),
           color: Theme.of(context).brightness == Brightness.dark
-              ? Colors.black87
+              ? Colors.black
               : Colors.white,
           boxShadow: [
             BoxShadow(
@@ -139,10 +142,12 @@ class _ChatScreenState extends State<ChatScreen> {
                                   itemBuilder: (context, index) {
                                     return Padding(
                                       padding:
-                                          EdgeInsets.symmetric(vertical: 10.0),
+                                          EdgeInsets.symmetric(vertical: 8.0),
                                       child: snapshot.data![index].type ==
                                               MessageType.INCOMING
                                           ? IncomingMessageBubble(
+                                              bubble_height: widget.bubble_height,
+                                              bubble_width: widget.bubble_width,
                                               message: snapshot.data![index],
                                               color:
                                                   widget.incomingMessageColor,
@@ -150,6 +155,8 @@ class _ChatScreenState extends State<ChatScreen> {
                                                   widget.senderAvatarColor,
                                             )
                                           : OutgoingMessageBubble(
+                                              bubble_height: widget.bubble_height,
+                                              bubble_width: widget.bubble_width,
                                               message: snapshot.data![index],
                                               color:
                                                   widget.outgoingMessageColor,

--- a/at_chat_flutter/lib/widgets/incoming_message_bubble.dart
+++ b/at_chat_flutter/lib/widgets/incoming_message_bubble.dart
@@ -9,14 +9,16 @@ class IncomingMessageBubble extends StatefulWidget {
   final Message? message;
   final Color color;
   final Color avatarColor;
-  final double bubble_height;
-  final double bubble_width;
+  final double bubbleHeightPadding;
+  final double bubbleWidthPadding;
 
   const IncomingMessageBubble(
       {Key? key,
       this.message,
       this.color = CustomColors.incomingMessageColor,
-      this.avatarColor = CustomColors.defaultColor, this.bubble_height = 12.0, this.bubble_width = 12.0})
+      this.avatarColor = CustomColors.defaultColor, 
+      this.bubbleHeightPadding = 12.0,
+      this.bubbleWidthPadding = 12.0})
       : super(key: key);
   @override
   _IncomingMessageBubbleState createState() => _IncomingMessageBubbleState();
@@ -49,7 +51,7 @@ class _IncomingMessageBubbleState extends State<IncomingMessageBubble> {
           width: 15.toWidth,
         ),
         Container(
-          padding: EdgeInsets.symmetric(horizontal: widget.bubble_width, vertical: widget.bubble_height),
+          padding: EdgeInsets.symmetric(horizontal: widget.bubbleWidthPadding, vertical: widget.bubbleHeightPadding),
           decoration: BoxDecoration(
             color: widget.color,
             borderRadius: BorderRadius.circular(10.toWidth),

--- a/at_chat_flutter/lib/widgets/incoming_message_bubble.dart
+++ b/at_chat_flutter/lib/widgets/incoming_message_bubble.dart
@@ -9,12 +9,14 @@ class IncomingMessageBubble extends StatefulWidget {
   final Message? message;
   final Color color;
   final Color avatarColor;
+  final double bubble_height;
+  final double bubble_width;
 
   const IncomingMessageBubble(
       {Key? key,
       this.message,
       this.color = CustomColors.incomingMessageColor,
-      this.avatarColor = CustomColors.defaultColor})
+      this.avatarColor = CustomColors.defaultColor, this.bubble_height = 12.0, this.bubble_width = 12.0})
       : super(key: key);
   @override
   _IncomingMessageBubbleState createState() => _IncomingMessageBubbleState();
@@ -47,7 +49,7 @@ class _IncomingMessageBubbleState extends State<IncomingMessageBubble> {
           width: 15.toWidth,
         ),
         Container(
-          padding: EdgeInsets.all(30.toHeight),
+          padding: EdgeInsets.symmetric(horizontal: widget.bubble_width, vertical: widget.bubble_height),
           decoration: BoxDecoration(
             color: widget.color,
             borderRadius: BorderRadius.circular(10.toWidth),

--- a/at_chat_flutter/lib/widgets/outgoing_message_bubble.dart
+++ b/at_chat_flutter/lib/widgets/outgoing_message_bubble.dart
@@ -9,14 +9,16 @@ class OutgoingMessageBubble extends StatefulWidget {
   final Message? message;
   final Color color;
   final Color avatarColor;
-  final double bubble_height;
-  final double bubble_width;
+  final double bubbleHeightPadding;
+  final double bubbleWidthPadding;
 
   const OutgoingMessageBubble(
       {Key? key,
       this.message,
       this.color = CustomColors.outgoingMessageColor,
-      this.avatarColor = CustomColors.defaultColor, this.bubble_height = 12.0, this.bubble_width = 12.0})
+      this.avatarColor = CustomColors.defaultColor,
+      this.bubbleHeightPadding = 12.0, 
+      this.bubbleWidthPadding = 12.0})
       : super(key: key);
   @override
   _OutgoingMessageBubbleState createState() => _OutgoingMessageBubbleState();
@@ -31,7 +33,7 @@ class _OutgoingMessageBubbleState extends State<OutgoingMessageBubble> {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Container(
-          padding: EdgeInsets.symmetric(horizontal: widget.bubble_width, vertical: widget.bubble_height),
+          padding: EdgeInsets.symmetric(horizontal: widget.bubbleWidthPadding, vertical: widget.bubbleHeightPadding),
           decoration: BoxDecoration(
             color: widget.color,
             borderRadius: BorderRadius.circular(10.toWidth),

--- a/at_chat_flutter/lib/widgets/outgoing_message_bubble.dart
+++ b/at_chat_flutter/lib/widgets/outgoing_message_bubble.dart
@@ -9,12 +9,14 @@ class OutgoingMessageBubble extends StatefulWidget {
   final Message? message;
   final Color color;
   final Color avatarColor;
+  final double bubble_height;
+  final double bubble_width;
 
   const OutgoingMessageBubble(
       {Key? key,
       this.message,
       this.color = CustomColors.outgoingMessageColor,
-      this.avatarColor = CustomColors.defaultColor})
+      this.avatarColor = CustomColors.defaultColor, this.bubble_height = 12.0, this.bubble_width = 12.0})
       : super(key: key);
   @override
   _OutgoingMessageBubbleState createState() => _OutgoingMessageBubbleState();
@@ -29,7 +31,7 @@ class _OutgoingMessageBubbleState extends State<OutgoingMessageBubble> {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Container(
-          padding: EdgeInsets.all(30.toHeight),
+          padding: EdgeInsets.symmetric(horizontal: widget.bubble_width, vertical: widget.bubble_height),
           decoration: BoxDecoration(
             color: widget.color,
             borderRadius: BorderRadius.circular(10.toWidth),


### PR DESCRIPTION
 **-What I did:**
 Created parameters for chat screen so that the message bubbles are customizable

**- How I did it**
Created instances "bubble_height" and "bubble_width" in both Message Bubble classes and
instead of edgeinsets.all(10) I set them to be a parameter and used those parameters in chatscreen.

bubble_height: widget.bubble_height,
bubble_width: widget.bubble_width,

**- How to verify it**
Run the chatscreen widget class and attempt to adjust the bubble sizes using bubble_width and bubble_height parameters

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
 Created parameters for chat screen so that the message bubbles are customizable