### PR TITLE
navigator canPop  check added before pop

### DIFF
--- a/at_onboarding_flutter/lib/services/custom_nav.dart
+++ b/at_onboarding_flutter/lib/services/custom_nav.dart
@@ -18,6 +18,8 @@ class CustomNav {
   }
 
   void pop(BuildContext context) {
-    Navigator.pop(context);
+    if (Navigator.of(context).canPop()) {
+      Navigator.pop(context);
+    }
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- added check if navigation stack is empty before navigation pop.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->