### PR TITLE
Migrate package pedantic to package lints

### DIFF
--- a/at_location_flutter/analysis_options.yaml
+++ b/at_location_flutter/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.11.0.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   exclude: [build/**]

--- a/at_location_flutter/pubspec.yaml
+++ b/at_location_flutter/pubspec.yaml
@@ -33,10 +33,10 @@ dependencies:
   at_commons: ^3.0.0
   at_contact: ^3.0.0
   at_common_flutter: ^2.0.2
-  pedantic: ^1.11.0
 
 
 dev_dependencies:
+  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
**- What I did:**
Migrate package pedantic to package flutter_lints in the at_location_flutter plugin project

**- How I did it**

- Remove package pedantic and add package flutter_lints as a dev_dependency in the pubspec.yaml file.
- Add package flutter_lints to the analysis_options.yaml file

**- How to verify it**
Run the `dart analyze` or `flutter analyze `command to identify possible problems in the code. 

**- Description for the changelog**
The package pedantic is now deprecated. Migrate package pedantic to package flutter_lints

Closes https://github.com/atsign-foundation/at_widgets/issues/222