### PR TITLE
 at_invitation_flutter: replace package pedantic

### DIFF
--- a/at_invitation_flutter/analysis_options.yaml
+++ b/at_invitation_flutter/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude: [build/**]
+  # strong-mode:
+  #   implicit-casts: false
+
+linter:
+  rules:
+    - camel_case_types

--- a/at_invitation_flutter/pubspec.yaml
+++ b/at_invitation_flutter/pubspec.yaml
@@ -18,12 +18,12 @@ dependencies:
   at_client_mobile: ^2.0.3
   at_lookup: ^2.0.3
 
-  pedantic: ^1.11.0
   url_launcher: ^6.0.7
   uuid: ^3.0.4
   flutter_pin_code_fields: ^1.1.0
 
 dev_dependencies:
+  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
**- What I did:**
- Migrate package pedantic to package flutter_lints

**- How I did it**
- Add package flutter_lints as a dev_dependency
- Create an analysis_options.yaml file and include package flutter_lints

**- How to verify it**
- Run the `dart analyze` or `flutter analyze` command to identify possible problems in the code.

**- Description for the changelog**
- The package pedantic is now deprecated. Migrate package pedantic to package flutter_lints

 Closes https://github.com/atsign-foundation/at_widgets/issues/221
