### PR TITLE
fix for showing file without extension for backup keys in desktop

### DIFF
--- a/at_onboarding_flutter/lib/screens/pair_atsign.dart
+++ b/at_onboarding_flutter/lib/screens/pair_atsign.dart
@@ -466,7 +466,10 @@ class _PairAtsignWidgetState extends State<PairAtsignWidget> {
     try {
       XTypeGroup typeGroup = XTypeGroup(
         label: 'images',
-        extensions: <String>['atKeys'],
+        extensions: <String>[
+          'atKeys',
+          ''
+        ], //empty quotes picks up files without extension
       );
       List<XFile> files =
           await openFiles(acceptedTypeGroups: <XTypeGroup>[typeGroup]);


### PR DESCRIPTION
**- Description for the changelog**
Desktop filter for 'atKeys' extension does not show file ending with 'atKeys 2'. Enabled files without extension to show with 'atKeys' files.
Fix for https://github.com/atsign-foundation/at_widgets/issues/376