### PR TITLE
fix: rename at_sync_ui_flutter example package

### DIFF
--- a/at_sync_ui_flutter/example/pubspec.yaml
+++ b/at_sync_ui_flutter/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: example
+name: at_sync_ui_flutter_example
 description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Renamed at_sync_ui_flutter example package from `example` to `at_sync_ui_flutter_example` to prevent naming conflicts in multi-package environments (at_mono).

See also: https://github.com/atsign-foundation/at_client_sdk/pull/746

**- How I did it**

Renamed the package.

**- How to verify it**

**- Description for the changelog**
fix: rename at_sync_ui_flutter example package
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->