### PR TITLE
fix: backupkey flutter snackbar issue

### DIFF
--- a/packages/at_backupkey_flutter/lib/widgets/backup_key_widget.dart
+++ b/packages/at_backupkey_flutter/lib/widgets/backup_key_widget.dart
@@ -247,17 +247,24 @@ PLEASE SECURELY SAVE YOUR KEYS. WE DO NOT HAVE ACCESS TO THEM AND CANNOT CREATE 
       }
       String tempFilePath = await _generateFile(aesEncryptedKeys);
       if (Platform.isAndroid || Platform.isIOS) {
-        await Share.shareFiles([tempFilePath],
-            sharePositionOrigin:
-                Rect.fromLTWH(0, 0, _size.width, _size.height / 2));
+        await Share.shareXFiles(
+          [XFile(tempFilePath)],
+          sharePositionOrigin:
+              Rect.fromLTWH(0, 0, _size.width, _size.height / 2),
+        ).then((ShareResult shareResult) {
+          if (shareResult.status == ShareResultStatus.success) {
+            ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('File saved successfully')));
+          }
+        });
       } else {
         final path =
             await getSavePath(suggestedName: '$atsign${Strings.backupKeyName}');
         final file = XFile(tempFilePath);
         await file.saveTo(path ?? '');
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('File saved successfully')));
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('File saved successfully')));
     } on Exception catch (ex) {
       _logger.severe('BackingUp keys throws $ex exception');
     } on Error catch (err) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed backup key showing success snackbar even before saving the actual key.

**- How I did it**
- added a check if file has been successfully saved or not, then only showing the snackbar.

**- How to verify it**
- run example on different platforms and try to save key

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->