### PR TITLE
fix: moved authenticate service before atSign server status check

### DIFF
--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_activate_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_activate_screen.dart
@@ -198,6 +198,9 @@ class _AtOnboardingActivateScreenState
       _onboardingService.setAtClientPreference =
           widget.config.atClientPreference;
 
+      authResponse = await _onboardingService.authenticate(atsign,
+          cramSecret: secret, status: OnboardingStatus.ACTIVATE);
+
       int round = 1;
       atSignStatus = await _onboardingService.checkAtSignServerStatus(atsign);
       while (atSignStatus != ServerStatus.activated) {
@@ -211,8 +214,7 @@ class _AtOnboardingActivateScreenState
         debugPrint("currentAtSignStatus: $atSignStatus");
       }
 
-      authResponse = await _onboardingService.authenticate(atsign,
-          cramSecret: secret, status: OnboardingStatus.ACTIVATE);
+
 
       if (authResponse == AtOnboardingResponseStatus.authSuccess) {
         if (atSignStatus == ServerStatus.teapot) {

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
@@ -705,6 +705,9 @@ class _AtOnboardingHomeScreenState extends State<AtOnboardingHomeScreen> {
       _onboardingService.setAtClientPreference =
           widget.config.atClientPreference;
 
+      authResponse = await _onboardingService.authenticate(atsign,
+          cramSecret: secret, status: widget.onboardStatus);
+
       int round = 1;
       atSignStatus = await _onboardingService.checkAtSignServerStatus(atsign);
       while (atSignStatus != ServerStatus.activated) {
@@ -717,8 +720,6 @@ class _AtOnboardingHomeScreenState extends State<AtOnboardingHomeScreen> {
         atSignStatus = await _onboardingService.checkAtSignServerStatus(atsign);
         debugPrint("currentAtSignStatus: $atSignStatus");
       }
-      authResponse = await _onboardingService.authenticate(atsign,
-          cramSecret: secret, status: widget.onboardStatus);
 
       _inprogressDialog.close();
       if (authResponse == AtOnboardingResponseStatus.authSuccess) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Moved `_onboardingService.authenticate` call before atSign server status check

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->