### PR TITLE
fix: use jsonDecode instead of string manipulation to read self_enc_key

### DIFF
--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -16,6 +17,7 @@ import 'package:at_onboarding_flutter/utils/at_onboarding_dimens.dart';
 import 'package:at_onboarding_flutter/utils/at_onboarding_error_util.dart';
 import 'package:at_onboarding_flutter/utils/at_onboarding_response_status.dart';
 import 'package:at_onboarding_flutter/utils/at_onboarding_strings.dart';
+import 'package:at_onboarding_flutter/utils/at_onboarding_app_constants.dart';
 import 'package:at_onboarding_flutter/widgets/at_onboarding_button.dart';
 import 'package:at_onboarding_flutter/widgets/at_onboarding_dialog.dart';
 import 'package:at_server_status/at_server_status.dart';
@@ -201,7 +203,8 @@ class _AtOnboardingHomeScreenState extends State<AtOnboardingHomeScreen> {
             .substring(0, keyData[1].length - 2)
             .split('":"');
         atsign = "@${params[0]}";
-        aesKey = params[1];
+        Map<String, String> keyMap = jsonDecode(fileContents);
+        aesKey = keyMap[AtOnboardingConstants.atSelfEncryptionKey];
       }
       if (fileContents == null || (aesKey == null && atsign == null)) {
         await showErrorDialog(_incorrectKeyFile);
@@ -276,7 +279,8 @@ class _AtOnboardingHomeScreenState extends State<AtOnboardingHomeScreen> {
             .substring(0, keyData[1].length - 2)
             .split('":"');
         atsign = "@${params[0]}";
-        aesKey = params[1];
+        Map<String, String> keyMap = jsonDecode(fileContents);
+        aesKey = keyMap[AtOnboardingConstants.atSelfEncryptionKey];
       }
       if (fileContents.isEmpty || (aesKey == null && atsign == null)) {
         await showErrorDialog(_incorrectKeyFile);

--- a/packages/at_onboarding_flutter/lib/utils/at_onboarding_app_constants.dart
+++ b/packages/at_onboarding_flutter/lib/utils/at_onboarding_app_constants.dart
@@ -20,6 +20,9 @@ class AtOnboardingConstants {
   static String contactAddress = 'support@atsign.com';
   static String activateAtSign = '/api/activateAtSign';
 
+  //.atKeys file key name
+  static String atSelfEncryptionKey = 'selfEncryptionKey';
+
   //Button titles
 
   static String get serverDomain => _rootDomain;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- feat: add constant for self_enc_key in util/at_onbaording_app_constants.dart ['selfEncryptionKey']
- fix: use jsonDecode instead of string manipulation to read self_enc_key

**- How I did it**
- used jsonDecode on file which was read as a string which returns a Map ty- 
pe object. Extracted self encryption key from the map using keyname that was introduced into at_onbaording_app_constants.dart

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: use jsonDecode instead of string manipulation to read self_enc_key