### PR TITLE
fix: contacts fetch removed when list is already present

### DIFF
--- a/packages/at_contacts_flutter/lib/services/contact_service.dart
+++ b/packages/at_contacts_flutter/lib/services/contact_service.dart
@@ -10,6 +10,7 @@ import 'package:at_contacts_flutter/models/contact_base_model.dart';
 import 'package:at_contacts_flutter/utils/init_contacts_service.dart';
 import 'package:at_contacts_flutter/utils/text_strings.dart';
 import 'package:at_lookup/at_lookup.dart';
+import 'package:flutter/material.dart';
 
 /// A service to handle CRUD operation on contacts
 class ContactService {
@@ -131,6 +132,13 @@ class ContactService {
   /// returns null if some error occurred.
   Future<List<AtContact>?> fetchContacts() async {
     try {
+      /// if contact list is already present, we will not fetch them again
+      if (baseContactList.isNotEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+          contactSink.add(baseContactList);
+        });
+        return contactList;
+      }
       selectedContacts = [];
       contactList = [];
       allContactsList = [];

--- a/packages/at_contacts_group_flutter/lib/services/group_service.dart
+++ b/packages/at_contacts_group_flutter/lib/services/group_service.dart
@@ -327,6 +327,13 @@ class GroupService {
   // ignore: always_declare_return_types
   fetchGroupsAndContacts({bool isDesktop = false}) async {
     try {
+      /// contacts list is already present, we do not fetch it again.
+      if (allContacts.isNotEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          _allContactsStreamController.add(allContacts);
+        });
+        return;
+      }
       allContacts = [];
       listContact = [];
       var contactList = await fetchContacts();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- If contact list is present then not fetching the data again.

**- How I did it**
- added a check to compare contact list

**- How to verify it**
- run the example and open contacts screen second time, data should load faster and spinner should not be shown.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->