### PR TITLE
fix: correct wrong Error message dialog when Wi-Fi is turned off

### DIFF
--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
@@ -574,11 +574,11 @@ class _AtOnboardingHomeScreenState extends State<AtOnboardingHomeScreen> {
         Navigator.pop(context, AtOnboardingResult.success(atsign: atsign!));
       } else if (authResponse == AtOnboardingResponseStatus.serverNotReached) {
         await _showAlertDialog(
-          AtOnboardingLocalizations.current.msg_atSign_not_registered,
+          AtOnboardingLocalizations.current.msg_atSign_unreachable,
         );
       } else if (authResponse == AtOnboardingResponseStatus.authFailed) {
         await _showAlertDialog(
-          AtOnboardingLocalizations.current.msg_atSign_unreachable,
+          AtOnboardingLocalizations.current.msg_atSign_not_registered,
         );
       } else {
         await showErrorDialog(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Correct wrong Error message dialog when Wi-Fi is turned off [#662](https://github.com/atsign-foundation/at_widgets/issues/662)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->