### PR TITLE
fix: extract AtOnboardingResetResult enum to at_onboarding_reset_resu…

### DIFF
--- a/packages/at_onboarding_flutter/lib/at_onboarding.dart
+++ b/packages/at_onboarding_flutter/lib/at_onboarding.dart
@@ -11,7 +11,6 @@ import 'package:at_onboarding_flutter/services/at_onboarding_theme.dart';
 import 'package:at_onboarding_flutter/services/onboarding_service.dart';
 import 'package:at_onboarding_flutter/utils/at_onboarding_app_constants.dart';
 import 'package:flutter/material.dart';
-import 'package:at_onboarding_flutter/screen/at_onboarding_reset_result.dart';
 
 
 class AtOnboarding {

--- a/packages/at_onboarding_flutter/lib/at_onboarding.dart
+++ b/packages/at_onboarding_flutter/lib/at_onboarding.dart
@@ -11,6 +11,8 @@ import 'package:at_onboarding_flutter/services/at_onboarding_theme.dart';
 import 'package:at_onboarding_flutter/services/onboarding_service.dart';
 import 'package:at_onboarding_flutter/utils/at_onboarding_app_constants.dart';
 import 'package:flutter/material.dart';
+import 'package:at_onboarding_flutter/screen/at_onboarding_reset_result.dart';
+
 
 class AtOnboarding {
   /// Using this function to get onboard atsing.

--- a/packages/at_onboarding_flutter/lib/at_onboarding_result.dart
+++ b/packages/at_onboarding_flutter/lib/at_onboarding_result.dart
@@ -8,6 +8,11 @@ enum AtOnboardingResultStatus {
   cancel, //User canceled
 }
 
+enum AtOnboardingResetResult {
+  cancelled,
+  success,
+}
+
 /// The result returned after onboard
 class AtOnboardingResult {
   /// Status of result

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_result.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_result.dart
@@ -1,4 +1,0 @@
-enum AtOnboardingResetResult {
-  cancelled,
-  success,
-}

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_result.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_result.dart
@@ -1,0 +1,4 @@
+enum AtOnboardingResetResult {
+  cancelled,
+  success,
+}

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_screen.dart
@@ -6,7 +6,7 @@ import 'package:at_onboarding_flutter/utils/at_onboarding_error_util.dart';
 import 'package:at_onboarding_flutter/widgets/at_onboarding_button.dart';
 import 'package:at_onboarding_flutter/widgets/at_onboarding_dialog.dart';
 import 'package:flutter/material.dart';
-import 'at_onboarding_reset_result.dart';
+import 'package:at_onboarding_flutter/at_onboarding_result.dart';
 
 
 

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_reset_screen.dart
@@ -6,11 +6,9 @@ import 'package:at_onboarding_flutter/utils/at_onboarding_error_util.dart';
 import 'package:at_onboarding_flutter/widgets/at_onboarding_button.dart';
 import 'package:at_onboarding_flutter/widgets/at_onboarding_dialog.dart';
 import 'package:flutter/material.dart';
+import 'at_onboarding_reset_result.dart';
 
-enum AtOnboardingResetResult {
-  cancelled,
-  success,
-}
+
 
 class AtOnboardingResetScreen extends StatefulWidget {
   final AtOnboardingConfig config;


### PR DESCRIPTION
Closes #507 

**- What I did**

Extract AtOnboardingResetResult to at_onboarding_reset_result.dart

**- How I did it**

- [x] Created ```at_onboarding_reset_result.dart``` under lib/screens/ and placed ```AtOnboardingResetResult``` in the file.
- [x] imported ```at_onboarding_reset_result.dart```  in ```at_onboarding_reset_screen.dart```.
- [x] Imported  ```at_onboarding_reset_result.dart```  in ```at_onboarding.dart```.

**- Description for the changelog**

extract AtOnboardingResetResult to at_onboarding_reset_result.dart