### PR TITLE
chore: at_chat pub changes

### DIFF
--- a/packages/at_chat_flutter/lib/services/chat_service.dart
+++ b/packages/at_chat_flutter/lib/services/chat_service.dart
@@ -77,7 +77,6 @@ class ChatService {
   Future<bool> startMonitor() async {
     if (!monitorStarted) {
       AtClientManager.getInstance()
-          .atClient
           .notificationService
           .subscribe(
               regex: atClientManager.atClient.getPreferences()!.namespace ?? '',

--- a/packages/at_chat_flutter/lib/services/chat_service.dart
+++ b/packages/at_chat_flutter/lib/services/chat_service.dart
@@ -77,6 +77,7 @@ class ChatService {
   Future<bool> startMonitor() async {
     if (!monitorStarted) {
       AtClientManager.getInstance()
+          .atClient
           .notificationService
           .subscribe(
               regex: atClientManager.atClient.getPreferences()!.namespace ?? '',

--- a/packages/at_chat_flutter/pubspec.yaml
+++ b/packages/at_chat_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.0.8
 homepage: https://docs.atsign.com/
 repository: https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_chat_flutter
 issue_tracker: https://github.com/atsign-foundation/at_widgets/issues
-documentation: https://atsign.gitbook.io/docs/~
+documentation: https://atsign.dev/docs/functional_architecture/libraries/#at_chat_flutter
 
 environment:
   sdk: ">=2.12.0 <4.0.0"

--- a/packages/at_chat_flutter/pubspec.yaml
+++ b/packages/at_chat_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.0.8
 homepage: https://docs.atsign.com/
 repository: https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_chat_flutter
 issue_tracker: https://github.com/atsign-foundation/at_widgets/issues
-documentation: https://atsign.dev/docs/functional_architecture/libraries/#at_chat_flutter
+documentation: https://atsign.gitbook.io/docs/~
 
 environment:
   sdk: ">=2.12.0 <4.0.0"

--- a/packages/at_chat_flutter/pubspec.yaml
+++ b/packages/at_chat_flutter/pubspec.yaml
@@ -4,7 +4,6 @@ version: 3.0.8
 homepage: https://docs.atsign.com/
 repository: https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_chat_flutter
 issue_tracker: https://github.com/atsign-foundation/at_widgets/issues
-documentation: https://atsign.gitbook.io/docs/~
 
 environment:
   sdk: ">=2.12.0 <4.0.0"


### PR DESCRIPTION
**- What I did**
Made changes for pubdev score
- Documentation Website was linking to a non existent page to old docs, just linked it to new gitbooks homepage.
- getInstance.notificationService warning fixed.
**- How I did it**

**- How to verify it**

**- Description for the changelog**
pubdev changes 