### PR TITLE
fix: Onboarding UTI for macOS

### DIFF
--- a/packages/at_backupkey_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_backupkey_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_chat_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_chat_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_common_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_common_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_contacts_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_contacts_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_contacts_group_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_contacts_group_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_events_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_events_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_follows_flutter/example/ios/Runner/Info.plist
+++ b/packages/at_follows_flutter/example/ios/Runner/Info.plist
@@ -45,5 +45,27 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_invitation_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_invitation_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_location_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_location_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_login_flutter/example/ios/Runner/Info.plist
+++ b/packages/at_login_flutter/example/ios/Runner/Info.plist
@@ -45,5 +45,27 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_notify_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_notify_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_onboarding_flutter/README.md
+++ b/packages/at_onboarding_flutter/README.md
@@ -136,6 +136,33 @@ and add the following keys:
 <true/>
 ```
 
+Then to ensure that the .atKeys file type is supported by macOS, open
+macos/Runner/Info.plist and add the following array:
+```
+<key>UTImportedTypeDeclarations</key>
+<array>
+  <dict>
+    <key>UTTypeIdentifier</key>
+    <string>com.atsign.atkeys</string>
+    <key>UTTypeConformsTo</key>
+    <array>
+      <string>public.json</string>
+    </array>
+    <key>UTTypeDescription</key>
+    <string>Atsign Cryptographic Key File</string>
+    <key>UTTypeTagSpecification</key>
+    <dict>
+      <key>public.filename-extension</key>
+      <array>
+        <string>atkeys</string>
+      </array>
+    </dict>
+    <key>UTTypeReferenceURL</key>
+    <string>https://github.com/atsign-foundation/at_protocol</string>
+  </dict>
+</array>
+```
+
 </details>
 
 ### 3. Migration guide
@@ -153,14 +180,14 @@ and add the following keys:
 
 ## Usage
 
-| Parameters              | Description                                                                                                                      |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| domain                  | Domain can differ based on the environment you are using.Default the plugin connects to 'root.atsign.org' to perform onboarding. |
-| atClientPreference      | The atClientPreference to continue with the onboarding.                                                                          |
-| rootEnvironment         | Permission to access the device's location is allowed even when the App is running in the background.                            |
-| appAPIKey               | API authentication key for getting free atsigns.                                                                                 |
-| isSwitchingAtsign       | Param specifies whether this action is switching atsign or not. Default is false                                                 |
-| atsign                  | The atsign name when change the primary atsign. Default is null                                                                  |
+| Parameters         | Description                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| domain             | Domain can differ based on the environment you are using.Default the plugin connects to 'root.atsign.org' to perform onboarding. |
+| atClientPreference | The atClientPreference to continue with the onboarding.                                                                          |
+| rootEnvironment    | Permission to access the device's location is allowed even when the App is running in the background.                            |
+| appAPIKey          | API authentication key for getting free atsigns.                                                                                 |
+| isSwitchingAtsign  | Param specifies whether this action is switching atsign or not. Default is false                                                 |
+| atsign             | The atsign name when change the primary atsign. Default is null                                                                  |
 
 ```dart
 TextButton

--- a/packages/at_onboarding_flutter/example/macos/Podfile.lock
+++ b/packages/at_onboarding_flutter/example/macos/Podfile.lock
@@ -3,14 +3,17 @@ PODS:
     - FlutterMacOS
   - biometric_storage (0.0.1):
     - FlutterMacOS
+  - device_info_plus (0.0.1):
+    - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - package_info_plus (0.0.1):
     - FlutterMacOS
-  - path_provider_macos (0.0.1):
+  - path_provider_foundation (0.0.1):
+    - Flutter
     - FlutterMacOS
-  - share_plus_macos (0.0.1):
+  - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
@@ -21,11 +24,12 @@ PODS:
 DEPENDENCIES:
   - at_file_saver (from `Flutter/ephemeral/.symlinks/plugins/at_file_saver/macos`)
   - biometric_storage (from `Flutter/ephemeral/.symlinks/plugins/biometric_storage/macos`)
+  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
-  - share_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
@@ -34,16 +38,18 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/at_file_saver/macos
   biometric_storage:
     :path: Flutter/ephemeral/.symlinks/plugins/biometric_storage/macos
+  device_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  path_provider_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
-  share_plus_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   url_launcher_macos:
@@ -52,12 +58,13 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   at_file_saver: 1fc6ed722f17c7a20ce79cce168d1100fcad4b95
   biometric_storage: 43caa6e7ef00e8e19c074216e7e1786dacda9e76
-  file_selector_macos: f1b08a781e66103e3ba279fd5d4024a2478b3af6
+  device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
+  file_selector_macos: 468fb6b81fac7c0e88d71317f3eec34c3b008ff9
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
-  share_plus_macos: 853ee48e7dce06b633998ca0735d482dd671ade4
-  shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
+  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7

--- a/packages/at_onboarding_flutter/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/at_onboarding_flutter/example/macos/Runner.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {

--- a/packages/at_onboarding_flutter/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/at_onboarding_flutter/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/at_onboarding_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_onboarding_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_onboarding_flutter/lib/at_onboarding.dart
+++ b/packages/at_onboarding_flutter/lib/at_onboarding.dart
@@ -12,7 +12,6 @@ import 'package:at_onboarding_flutter/services/onboarding_service.dart';
 import 'package:at_onboarding_flutter/utils/at_onboarding_app_constants.dart';
 import 'package:flutter/material.dart';
 
-
 class AtOnboarding {
   /// Using this function to get onboard atsing.
   ///
@@ -65,12 +64,12 @@ class AtOnboarding {
 
       if (result is AtOnboardingResult) {
         return result;
-      } 
-      
-      return AtOnboardingResult.cancelled();
-    } 
+      }
 
-    if (context.mounted){
+      return AtOnboardingResult.cancelled();
+    }
+
+    if (context.mounted) {
       final result = await Navigator.push(
         context,
         MaterialPageRoute(
@@ -80,7 +79,7 @@ class AtOnboarding {
             );
           },
         ),
-      ); 
+      );
 
       if (result is AtOnboardingResult) {
         //Update primary atsign after onboard success
@@ -89,7 +88,7 @@ class AtOnboarding {
           await changePrimaryAtsign(atsign: result.atsign!);
         }
         return result;
-      } 
+      }
     }
 
     return AtOnboardingResult.cancelled();
@@ -101,8 +100,8 @@ class AtOnboarding {
   }) async {
     /// Initial Setup
     await _initialSetup(context);
-    
-    if(context.mounted){
+
+    if (context.mounted) {
       final result = await Navigator.push(
         context,
         MaterialPageRoute(
@@ -119,7 +118,7 @@ class AtOnboarding {
         return result;
       }
     }
-      
+
     return AtOnboardingResult.cancelled();
   }
 
@@ -135,7 +134,7 @@ class AtOnboarding {
     /// Initial Setup
     await _initialSetup(context);
 
-    if(context.mounted){
+    if (context.mounted) {
       final result = await Navigator.push(context,
           MaterialPageRoute(builder: (BuildContext context) {
         return AtOnboardingResetScreen(config: config);

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
@@ -521,19 +521,15 @@ class _AtOnboardingHomeScreenState extends State<AtOnboardingHomeScreen> {
 
   Future<String?> _desktopKeyPicker() async {
     try {
-      // ignore: prefer_const_constructors
-      XTypeGroup typeGroup = XTypeGroup(
-        label: 'images',
-        // ignore: prefer_const_literals_to_create_immutables
-        extensions: <String>['atKeys'],
+      XFile? file = await openFile(
+        acceptedTypeGroups: const [
+          // General file extensions
+          XTypeGroup(extensions: ['atKeys', 'atkeys']),
+          // Apple specific UTIs
+          XTypeGroup(uniformTypeIdentifiers: ['com.atsign.atkeys']),
+        ],
       );
-      List<XFile> files =
-          await openFiles(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
-      if (files.isEmpty) {
-        return null;
-      }
-      XFile file = files[0];
-      return file.path;
+      return file?.path;
     } catch (e) {
       _logger.severe('Error in desktopImagePicker $e');
       return null;

--- a/packages/at_sync_ui_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_sync_ui_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/packages/at_theme_flutter/example/macos/Runner/Info.plist
+++ b/packages/at_theme_flutter/example/macos/Runner/Info.plist
@@ -28,5 +28,27 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.atsign.atkeys</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Atsign Cryptographic Key File</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>atkeys</string>
+				</array>
+			</dict>
+			<key>UTTypeReferenceURL</key>
+			<string>https://github.com/atsign-foundation/at_protocol</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Documented additional setup steps for at_onboarding_flutter with macOS
  - It is now required that the developer adds a Universal Type Identifier (UTI) for the .atKeys file extension in order to enable a proper onboarding experience in macOS
- Added this additional configuration to each of the example apps
**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: Onboarding UTI for macOS
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->