### PR TITLE
ci: Restore static analysis of packages that were previously failing

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -20,19 +20,19 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          # at_backupkey_flutter
-          #- at_chat_flutter
+          - at_backupkey_flutter
+          - at_chat_flutter
           - at_common_flutter
           - at_contacts_flutter
           - at_contacts_group_flutter
           - at_events_flutter
-          #- at_follows_flutter
-          #- at_invitation_flutter
-          #- at_location_flutter
-          #- at_login_flutter
+          - at_follows_flutter
+          - at_invitation_flutter
+          - at_location_flutter
+          - at_login_flutter
           - at_notify_flutter
           - at_onboarding_flutter
-          #- at_sync_ui_flutter
+          - at_sync_ui_flutter
           - at_theme_flutter
 
     steps:


### PR DESCRIPTION
Closes #769 

**- What I did**

Brought previously skipped packages back into test matrix

**- How I did it**

Removed comment `#` from packages that had to be skipped

**- How to verify it**

CI run for this PR should complete static_analysis without failure.

**- Description for the changelog**

ci: Restore static analysis of packages that were previously failing
