### PR TITLE
fix: replace deprecated elements with equivalent up-to-date items

### DIFF
--- a/packages/at_onboarding_flutter/example/lib/main.dart
+++ b/packages/at_onboarding_flutter/example/lib/main.dart
@@ -51,22 +51,16 @@ class _MyAppState extends State<MyApp> {
           theme: ThemeData().copyWith(
             brightness: Brightness.light,
             primaryColor: const Color(0xFFf4533d),
-            colorScheme: ThemeData.light().colorScheme.copyWith(
+            scaffoldBackgroundColor: Colors.white, colorScheme: ThemeData.light().colorScheme.copyWith(
                   primary: const Color(0xFFf4533d),
-                ),
-            // ignore: deprecated_member_use
-            backgroundColor: Colors.white,
-            scaffoldBackgroundColor: Colors.white,
+                ).copyWith(surface: Colors.white),
           ),
           darkTheme: ThemeData().copyWith(
             brightness: Brightness.dark,
             primaryColor: Colors.blue,
-            colorScheme: ThemeData.dark().colorScheme.copyWith(
+            scaffoldBackgroundColor: Colors.grey[850], colorScheme: ThemeData.dark().colorScheme.copyWith(
                   primary: Colors.blue,
-                ),
-            // ignore: deprecated_member_use
-            backgroundColor: Colors.grey[850],
-            scaffoldBackgroundColor: Colors.grey[850],
+                ).copyWith(surface: Colors.grey[850]),
           ),
           locale: _currentLocale,
           localizationsDelegates: const [

--- a/packages/at_onboarding_flutter/example/lib/main.dart
+++ b/packages/at_onboarding_flutter/example/lib/main.dart
@@ -52,8 +52,8 @@ class _MyAppState extends State<MyApp> {
             brightness: Brightness.light,
             primaryColor: const Color(0xFFf4533d),
             scaffoldBackgroundColor: Colors.white, colorScheme: ThemeData.light().colorScheme.copyWith(
-                  primary: const Color(0xFFf4533d),
-                ).copyWith(surface: Colors.white),
+                  primary: const Color(0xFFf4533d), surface: Colors.white
+                ).copyWith(),
           ),
           darkTheme: ThemeData().copyWith(
             brightness: Brightness.dark,

--- a/packages/at_onboarding_flutter/example/lib/main.dart
+++ b/packages/at_onboarding_flutter/example/lib/main.dart
@@ -51,16 +51,17 @@ class _MyAppState extends State<MyApp> {
           theme: ThemeData().copyWith(
             brightness: Brightness.light,
             primaryColor: const Color(0xFFf4533d),
-            scaffoldBackgroundColor: Colors.white, colorScheme: ThemeData.light().colorScheme.copyWith(
-                  primary: const Color(0xFFf4533d), surface: Colors.white
-                ).copyWith(),
+            scaffoldBackgroundColor: Colors.white,
+            colorScheme: ThemeData.light().colorScheme.copyWith(
+                primary: const Color(0xFFf4533d), surface: Colors.white),
           ),
           darkTheme: ThemeData().copyWith(
             brightness: Brightness.dark,
             primaryColor: Colors.blue,
-            scaffoldBackgroundColor: Colors.grey[850], colorScheme: ThemeData.dark().colorScheme.copyWith(
-                  primary: Colors.blue,
-                ).copyWith(surface: Colors.grey[850]),
+            scaffoldBackgroundColor: Colors.grey[850],
+            colorScheme: ThemeData.dark()
+                .colorScheme
+                .copyWith(primary: Colors.blue, surface: Colors.grey[850]),
           ),
           locale: _currentLocale,
           localizationsDelegates: const [

--- a/packages/at_onboarding_flutter/example/lib/switch_atsign.dart
+++ b/packages/at_onboarding_flutter/example/lib/switch_atsign.dart
@@ -44,8 +44,7 @@ class _AtSignBottomSheetState extends State<AtSignBottomSheet> {
               child: Container(
                 height: 100,
                 width: screenSize.width,
-                // ignore: deprecated_member_use
-                color: Theme.of(context).backgroundColor,
+                color: Theme.of(context).canvasColor,
                 child: Row(
                   children: [
                     Expanded(
@@ -101,7 +100,7 @@ class _AtSignBottomSheetState extends State<AtSignBottomSheet> {
                               Text(
                                 widget.atSignList[index],
                                 // ignore: deprecated_member_use
-                                style: Theme.of(context).textTheme.bodyText1,
+                                style: Theme.of(context).textTheme.bodyMedium,
                               )
                             ],
                           ),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_widgets/issues/843

**- What I did**
- Replaced deprecated elements in at_onboarding_flutter's example app with up-to-date design elements

**- How I did it**
- BackgroundColor in MaterialApp() was previously deprecated and now removed. The latest version's equivalent of BackgroundColor is called 'surface' which is now used in the examples
- Also Changed: 

1.  color: Theme.of(context).backgroundColor -> color: Theme.of(context).canvasColor

2. style: Theme.of(context).textTheme.bodyText1 -> style: Theme.of(context).textTheme.bodyMedium,

**- How to verify it**
- Static analysis should pass. Also, requires manual testing to ensure design elements are not broken

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: replace deprecated elements with equivalent up-to-date items