### PR TITLE
fix: replace deprecated elements with equivalent up-to-date items in at_commons_flutter

### DIFF
--- a/packages/at_common_flutter/example/lib/main.dart
+++ b/packages/at_common_flutter/example/lib/main.dart
@@ -25,13 +25,13 @@ class MyApp extends StatelessWidget {
           theme: ThemeData(
             brightness: Brightness.light,
             primaryColor: const Color(0xFFf04924),
-            backgroundColor: Colors.white,
+            colorScheme: ThemeData.light().colorScheme.copyWith(surface: Colors.white),
           ),
           darkTheme: ThemeData(
             brightness: Brightness.dark,
             fontFamily: 'RobotoSlab',
             primaryColor: const Color(0xFFF05E3E),
-            backgroundColor: Colors.black,
+            colorScheme: ThemeData.dark().colorScheme.copyWith(surface: Colors.black),
           ),
           themeMode: snapshot.data,
           title: 'Example App',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_widgets/issues/842

**- What I did**
- Replaced deprecated elements inat_commons_flutter's example app with up-to-date design elements

**- How I did it**
- BackgroundColor in MaterialApp() was previously deprecated and now removed. The latest version's equivalent of BackgroundColor is called 'surface' which is now used in the examples.

**- How to verify it**
- Static analysis should pass. Also, requires manual testing to ensure design elements are not broken

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: replace deprecated elements with equivalent up-to-date items in at_commons_flutter