### PR TITLE
fix: Uptake at_client_mobile 3.2.18

### DIFF
--- a/packages/at_onboarding_flutter/test/screens/at_onboarding_start_screen_test.dart
+++ b/packages/at_onboarding_flutter/test/screens/at_onboarding_start_screen_test.dart
@@ -14,7 +14,7 @@ class MockOnboardingService extends Mock implements OnboardingService {
   }
 
   @override
-  Future<bool> onboard() {
+  Future<bool> onboard({String? cramSecret}) {
     throw OnboardingStatus.ACTIVATE;
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Uptake at_client_mobile 3.2.18 changes into at_onboarding_flutter.

**- How I did it**
- Refactor "onboard" and "authenticate" methods to use "AtAuthService" instead of  "AtClientService" which is introduced in at_client_mobile.
- In onboarding_service.dart, mark "atClientServiceMap" as deprecated. This is used in the wavi mobile apps. Perhaps might have its usage in other mobile apps also. Hence marking as deprecated and adding instance of "AtClientService" as value to prevent breaking change.
- Added "enroll" method to submit a new enrollment request

**- How to verify it**
- Manually tested with at_onboarding_flutter example and wavi mobile app.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
