### PR TITLE
fix(at_onboarding_flutter): fixed activation of an already acquired atsign

### DIFF
--- a/packages/at_onboarding_flutter/CHANGELOG.md
+++ b/packages/at_onboarding_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.11
+
+- **FIX**: Fixed an issue preventing an already acquired atSign from being activated
+
 ## 6.1.10
 
 - **FIX**: Fixed an issue preventing a new atSign from being activated

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_activate_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_activate_screen.dart
@@ -198,11 +198,10 @@ class _AtOnboardingActivateScreenState
     }
   }
 
-  Future<dynamic> _processSharedSecret({
+  Future<void> _processSharedSecret({
     required String atsign,
     required String secret,
   }) async {
-    dynamic authResponse;
     try {
       atsign = atsign.startsWith('@') ? atsign : '@$atsign';
 
@@ -221,12 +220,13 @@ class _AtOnboardingActivateScreenState
 
       String? previousAtsign = _onboardingService.currentAtsign;
       _onboardingService.setAtsign = atsign;
-      authResponse = await _onboardingService.onboard(
+      final authResponse = await _onboardingService.onboard(
         cramSecret: secret,
       );
 
       int round = 1;
-      atSignStatus = await _onboardingService.checkAtSignServerStatus(atsign);
+      var atSignStatus =
+          await _onboardingService.checkAtSignServerStatus(atsign);
       while (atSignStatus != ServerStatus.activated) {
         if (round > 10) {
           break;
@@ -238,12 +238,11 @@ class _AtOnboardingActivateScreenState
         debugPrint("currentAtSignStatus: $atSignStatus");
       }
 
-      if (authResponse != AtOnboardingResponseStatus.authSuccess ||
-          atSignStatus == ServerStatus.teapot) {
+      if (!authResponse || atSignStatus == ServerStatus.teapot) {
         _onboardingService.setAtsign = previousAtsign;
       }
 
-      if (authResponse == AtOnboardingResponseStatus.authSuccess) {
+      if (authResponse) {
         if (atSignStatus == ServerStatus.teapot) {
           await _showAlertDialog(
             AtOnboardingLocalizations.current.msg_atSign_unreachable,
@@ -263,14 +262,6 @@ class _AtOnboardingActivateScreenState
 
         if (!mounted) return;
         Navigator.pop(context, AtOnboardingResult.success(atsign: atsign));
-      } else if (authResponse == AtOnboardingResponseStatus.serverNotReached) {
-        await _showAlertDialog(
-          AtOnboardingLocalizations.current.msg_atSign_unreachable,
-        );
-      } else if (authResponse == AtOnboardingResponseStatus.authFailed) {
-        await _showAlertDialog(
-          AtOnboardingLocalizations.current.error_authenticated_failed,
-        );
       } else {
         await showErrorDialog(
           AtOnboardingLocalizations.current.title_session_expired,
@@ -294,7 +285,6 @@ class _AtOnboardingActivateScreenState
         );
       }
     }
-    return authResponse;
   }
 
   Future<void> _showAlertDialog(dynamic errorMessage, {String? title}) async {

--- a/packages/at_onboarding_flutter/pubspec.yaml
+++ b/packages/at_onboarding_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: at_onboarding_flutter
 description: A Flutter plugin project for onboarding any atSign in atPlatform
   apps with ease. Provides a QRscanner option and an upload key file option to
   authenticate.
-version: 6.1.10
+version: 6.1.11
 homepage: https://docs.atsign.com/
 repository: https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_onboarding_flutter
 issue_tracker: https://github.com/atsign-foundation/at_widgets/issues


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Corrected navigation logic to use `bool` type returned from `_onboardingService.onboard()` instead of `AtOnboardingResponseStatus`.
- Also bumped package version

**- How to verify it**
- Run the example app in `at_onboarding_flutter` and try to activate an atSign acquired through https://my.atsign.com/

**- Description for the changelog**
fixed activation of an already acquired atsign
