### PR TITLE
fix: use passed in request if available

### DIFF
--- a/packages/at_onboarding_flutter/lib/services/onboarding_service.dart
+++ b/packages/at_onboarding_flutter/lib/services/onboarding_service.dart
@@ -121,17 +121,20 @@ class OnboardingService {
           await authService.authenticate(atAuthRequest);
       return atAuthResponse.isSuccessful;
     }
+
+    var req = atOnboardingRequest ?? AtOnboardingRequest(_atsign!);
+    req.appName =
+        (atOnboardingRequest != null && atOnboardingRequest.appName != null)
+            ? atOnboardingRequest.appName
+            : 'system';
+    req.deviceName =
+        (atOnboardingRequest != null && atOnboardingRequest.deviceName != null)
+            ? atOnboardingRequest.deviceName
+            : 'default-device';
     var onboardingResponse = await authService.onboard(
-        AtOnboardingRequest(_atsign!)
-          ..appName = (atOnboardingRequest != null &&
-                  atOnboardingRequest.appName != null)
-              ? atOnboardingRequest.appName
-              : 'system'
-          ..deviceName = (atOnboardingRequest != null &&
-                  atOnboardingRequest.deviceName != null)
-              ? atOnboardingRequest.deviceName
-              : 'default-device',
-        cramSecret: cramSecret);
+      req,
+      cramSecret: cramSecret,
+    );
     _logger.finer('onboardingResponse: $onboardingResponse');
     if (onboardingResponse.isSuccessful) {
       // Initializing "AtClientService" and adding to it map for backward compatibility.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fixed a bug where the AtOnboardingRequest passed in to `OnboardingServer.onboard` was being ignored, thus the rootDomain wasn't being set. We now use the passed in onboarding request before applying modifications to it to do onboarding.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: use passed in request if available
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
